### PR TITLE
tests: cover the emitters added since the partition sync — fix the coverage gate

### DIFF
--- a/crates/rustc_codegen_tile/src/mlir_to_msl.rs
+++ b/crates/rustc_codegen_tile/src/mlir_to_msl.rs
@@ -14341,6 +14341,10 @@ mod emit_tail_tests {
         check(|o| emit_absmax_msl(o, "float"), "uint gid = row * tcount + tid;", "emit_absmax_msl");
     }
     #[test]
+    fn t_emit_add_inplace_batched_msl() {
+        check(|o| emit_add_inplace_batched_msl(o), "a[off]+=b[off];", "emit_add_inplace_batched_msl");
+    }
+    #[test]
     fn t_emit_argmax_msl() {
         check(|o| emit_argmax_msl(o, "float"), "uint base = row * num_elements;  // num_elements reused as cols", "emit_argmax_msl");
     }
@@ -14379,6 +14383,26 @@ mod emit_tail_tests {
     #[test]
     fn t_emit_attention_prefill_msl() {
         check(|o| emit_attention_prefill_msl(o), "const uint q_off = qi * num_heads * head_dim + head * head_dim;", "emit_attention_prefill_msl");
+    }
+    #[test]
+    fn t_emit_attn_decode_batched_msl() {
+        check(|o| emit_attn_decode_batched_msl(o), "kernel void attn_decode_batched(", "emit_attn_decode_batched_msl");
+    }
+    #[test]
+    fn t_emit_attn_decode_combine_msl() {
+        check(|o| emit_attn_decode_combine_msl(o), "out[hg*dh+e] = (l > 0.0f) ? (acc/l) : 0.0f;", "emit_attn_decode_combine_msl");
+    }
+    #[test]
+    fn t_emit_attn_decode_splitk_msl() {
+        check(|o| emit_attn_decode_splitk_msl(o), "threadgroup float red[256]; threadgroup float s_sh;", "emit_attn_decode_splitk_msl");
+    }
+    #[test]
+    fn t_emit_attn_decode_splitk_v2_msl() {
+        check(|o| emit_attn_decode_splitk_v2_msl(o), "device const float4* q4 = (device const float4*)(q + hg*128);", "emit_attn_decode_splitk_v2_msl");
+    }
+    #[test]
+    fn t_emit_attn_decode_v4_batched_msl() {
+        check(|o| emit_attn_decode_v4_batched_msl(o), "kernel void attn_decode_v4_batched(", "emit_attn_decode_v4_batched_msl");
     }
     #[test]
     fn t_emit_bin_fuse_f32_msl() {
@@ -14646,6 +14670,10 @@ mod emit_tail_tests {
         check(|o| emit_kv_cache_update_prefill_msl(o), "uint dst_idx = head * max_seq * head_dim + (start_pos + si) * head_dim + d;", "emit_kv_cache_update_prefill_msl");
     }
     #[test]
+    fn t_emit_kv_write_batched_msl() {
+        check(|o| emit_kv_write_batched_msl(o), "caches[h*max_seq*head_dim+pos*head_dim+d]=srcs[h*head_dim+d];", "emit_kv_write_batched_msl");
+    }
+    #[test]
     fn t_emit_l2dist_msl() {
         check(|o| emit_l2dist_msl(o, "float"), "if (tid == 0) p2[q_row * num_codes + k] = sdata[0];", "emit_l2dist_msl");
     }
@@ -14656,6 +14684,10 @@ mod emit_tail_tests {
     #[test]
     fn t_emit_matmul_f16_msl() {
         check(|o| emit_matmul_f16_msl(o), "for (uint n = tid; n < N; n += tcount) {", "emit_matmul_f16_msl");
+    }
+    #[test]
+    fn t_emit_matmul_f16_simdgroup_msl() {
+        check(|o| emit_matmul_f16_simdgroup_msl(o), "simdgroup_multiply_accumulate(acc, a, b, acc);", "emit_matmul_f16_simdgroup_msl");
     }
     #[test]
     fn t_emit_matmul_transposed_msl() {
@@ -14672,6 +14704,26 @@ mod emit_tail_tests {
     #[test]
     fn t_emit_matvec_f16_msl() {
         check(|o| emit_matvec_f16_msl(o), "for (uint s = 0; s < num_simd_groups; s++) total += shared[s];", "emit_matvec_f16_msl");
+    }
+    #[test]
+    fn t_emit_matvec_i8_v4_msl() {
+        check(|o| emit_matvec_i8_v4_msl(o), "sum += dot(a4[i], float4(w4[i]));", "emit_matvec_i8_v4_msl");
+    }
+    #[test]
+    fn t_emit_matvec_i8_v4_batched_msl() {
+        check(|o| emit_matvec_i8_v4_batched_msl(o), "float acc[8] = {0,0,0,0,0,0,0,0};", "emit_matvec_i8_v4_batched_msl");
+    }
+    #[test]
+    fn t_emit_matvec_q4k_coop_msl() {
+        check(|o| emit_matvec_q4k_coop_msl(o), "kernel void matvec_q4k_coop(", "emit_matvec_q4k_coop_msl");
+    }
+    #[test]
+    fn t_emit_matvec_q4k_msl() {
+        check(|o| emit_matvec_q4k_msl(o), "device const uchar *wr = p0 + (ulong)row * (ulong)n_blk * 144ul;", "emit_matvec_q4k_msl");
+    }
+    #[test]
+    fn t_emit_matvec_q4k_reg_msl() {
+        check(|o| emit_matvec_q4k_reg_msl(o), "const int first_row = ((int)tgpig.x * 2 + (int)sgitg) * 4;", "emit_matvec_q4k_reg_msl");
     }
     #[test]
     fn t_emit_max_msl() {
@@ -14715,6 +14767,10 @@ mod emit_tail_tests {
     #[test]
     fn t_emit_mul_mv_f16_f32_pair_4_msl() {
         check(|o| emit_mul_mv_f16_f32_pair_4_msl(o), "const uint64_t offset0 = (uint64_t)(r0 + row) * (uint64_t)nb01 + (uint64_t)(i12 / r2) * (uint64_t)nb02 + (uint64_t)(i13 / r3) * (uint64_t)nb03;", "emit_mul_mv_f16_f32_pair_4_msl");
+    }
+    #[test]
+    fn t_emit_mul_mv_gate_up_swiglu_q4_K_f32_msl() {
+        check(|o| emit_mul_mv_gate_up_swiglu_q4_K_f32_msl(o), "Dense: no ids/token demux. gate_w=p0, up_w=p1, x=p2", "emit_mul_mv_gate_up_swiglu_q4_K_f32_msl");
     }
     #[test]
     fn t_emit_mul_mv_id_iq2_xxs_f32_msl() {
@@ -14761,6 +14817,14 @@ mod emit_tail_tests {
         check(|o| emit_mul_mv_q8_0_f32_msl(o), "const uint64_t offset0 = (uint64_t)(r0 + (uint)row) * (uint64_t)nb01 + (uint64_t)(i12 / r2) * (uint64_t)nb02 + (uint64_t)(i13 / r3) * (uint64_t)nb03;", "emit_mul_mv_q8_0_f32_msl");
     }
     #[test]
+    fn t_emit_mul_mv_qkv_q4_K_f32_msl() {
+        check(|o| emit_mul_mv_qkv_q4_K_f32_msl(o), "Map first_row -> (matrix weights, output buffer, local out row).", "emit_mul_mv_qkv_q4_K_f32_msl");
+    }
+    #[test]
+    fn t_emit_mul_mv_rms_gate_up_swiglu_q4_K_f32_msl() {
+        check(|o| emit_mul_mv_rms_gate_up_swiglu_q4_K_f32_msl(o), "threadgroup float xs[4096];", "emit_mul_mv_rms_gate_up_swiglu_q4_K_f32_msl");
+    }
+    #[test]
     fn t_emit_mul_mv_t_t_4_disp_msl() {
         check(|o| emit_mul_mv_t_t_4_disp_msl(o, false), "const uint64_t offset0 = (uint64_t)(r0 + row) * (uint64_t)nb01 + (uint64_t)(i12 / r2) * (uint64_t)nb02 + (uint64_t)(i13 / r3) * (uint64_t)nb03;", "emit_mul_mv_t_t_4_disp_msl");
         check(|o| emit_mul_mv_t_t_4_disp_msl(o, true), "", "emit_mul_mv_t_t_4_disp_msl#v0");
@@ -14796,6 +14860,18 @@ mod emit_tail_tests {
         check(|o| emit_mul_mv_t_t_short_msl(o, true), "", "emit_mul_mv_t_t_short_msl#v0");
     }
     #[test]
+    fn t_emit_partition_cell_msl() {
+        // The destination is the LAST buffer (p{n-1}), never a hardcoded p1:
+        // under the default qualifier rule only the last buffer is writable.
+        check(|o| emit_partition_cell_msl(o, 4), "p3[r * tile_cols + c] = p0[base + r * src_cols + c];", "emit_partition_cell_msl#p3");
+        check(|o| emit_partition_cell_msl(o, 2), "p1[r * tile_cols + c] = p0[base + r * src_cols + c];", "emit_partition_cell_msl#p1");
+    }
+    #[test]
+    fn t_emit_partition_cell_store_msl() {
+        check(|o| emit_partition_cell_store_msl(o, 4), "p3[base + r * src_cols + c] = p0[r * tile_cols + c];", "emit_partition_cell_store_msl#p3");
+        check(|o| emit_partition_cell_store_msl(o, 2), "p1[base + r * src_cols + c] = p0[r * tile_cols + c];", "emit_partition_cell_store_msl#p1");
+    }
+    #[test]
     fn t_emit_quantize_msl() {
         check(|o| emit_quantize_msl(o, "float"), "uint gid = row * tcount + tid;", "emit_quantize_msl");
     }
@@ -14821,6 +14897,14 @@ mod emit_tail_tests {
         check(|o| emit_rms_norm_msl(o, "float"), "if (simd_group == 0 && simd_lane < MAX_SG) rms_shared[simd_lane] = (", "emit_rms_norm_msl");
     }
     #[test]
+    fn t_emit_rms_norm_mul_batched_msl() {
+        check(|o| emit_rms_norm_mul_batched_msl(o), "s=simd_sum(s); if(sl==0)sh[si]=s;", "emit_rms_norm_mul_batched_msl");
+    }
+    #[test]
+    fn t_emit_rms_norm_mul_v4_batched_msl() {
+        check(|o| emit_rms_norm_mul_v4_batched_msl(o), "float4 v=x4[i]; s+=dot(v,v);", "emit_rms_norm_mul_v4_batched_msl");
+    }
+    #[test]
     fn t_emit_rope_dsv4_msl() {
         check(|o| emit_rope_dsv4_msl(o), "float corr_lo = floor((float)n_dims * log((float)n_ctx_orig / (beta_fast * 2.0f * M_PI_F)) / (2.0f * log(freq_base)));", "emit_rope_dsv4_msl");
     }
@@ -14829,12 +14913,20 @@ mod emit_tail_tests {
         check(|o| emit_rope_inplace_msl(o), "float freq = 1.0f / pow(theta, 2.0f * float(i) / float(head_dim));", "emit_rope_inplace_msl");
     }
     #[test]
+    fn t_emit_rope_inplace_split_msl() {
+        check(|o| emit_rope_inplace_split_msl(o), "uint total_pairs = num_heads * half_dim;", "emit_rope_inplace_split_msl");
+    }
+    #[test]
     fn t_emit_rope_msl() {
         check(|o| emit_rope_msl(o, "float"), "float freq = 1.0f / pow(10000.0f, 2.0f * (float)i / (float)cols);", "emit_rope_msl");
     }
     #[test]
     fn t_emit_rope_prefill_msl() {
         check(|o| emit_rope_prefill_msl(o), "float freq = 1.0f / pow(theta, 2.0f * float(i) / float(head_dim));", "emit_rope_prefill_msl");
+    }
+    #[test]
+    fn t_emit_rope_split_batched_msl() {
+        check(|o| emit_rope_split_batched_msl(o), "ps[base+i]=x0*ca-x1*sa; ps[base+half_dim+i]=x1*ca+x0*sa;", "emit_rope_split_batched_msl");
     }
     #[test]
     fn t_emit_sample_top_p_msl() {
@@ -14868,6 +14960,10 @@ mod emit_tail_tests {
     #[test]
     fn t_emit_silu_msl() {
         check(|o| emit_silu_msl(o), "p1[gid] = v / (1.0f + exp(-v));", "emit_silu_msl");
+    }
+    #[test]
+    fn t_emit_silu_mul_batched_msl() {
+        check(|o| emit_silu_mul_batched_msl(o), "o[off]=(x/(1.0f+exp(-x)))*u[off];", "emit_silu_mul_batched_msl");
     }
     #[test]
     fn t_emit_silu_mul_msl() {

--- a/crates/rustc_codegen_tile/src/mlir_to_pto.rs
+++ b/crates/rustc_codegen_tile/src/mlir_to_pto.rs
@@ -8176,6 +8176,119 @@ module {
     }
 
     #[test]
+    fn test_pto_partition_cell_lowers_to_partition_view() {
+        // Cell (1,1) of a 16x32 partition of a 32x64 tile: base offsets are
+        // [row=16, col=32], supplied DIRECTLY (never via the flat-offset decode,
+        // which mis-derives the row when Tc != C).
+        let mlir = r#"
+module {
+  llvm.func @part_cell(%arg0: !llvm.ptr<1>, %arg1: !llvm.ptr<1>) attributes {hacc.entry} {
+    %t = llvm.call @__tile_load_f32(%arg0, %c32, %c64) : (!llvm.ptr<1>, i32, i32) -> i32
+    %cell = llvm.call @__tile_partition_cell_f32(%t, %c1, %c1, %c16, %c32) : (i32, i32, i32, i32, i32) -> i32
+    llvm.call @__tile_store_f32(%arg1, %cell, %c16, %c32) : (!llvm.ptr<1>, i32, i32, i32) -> ()
+    llvm.return
+  }
+}
+"#;
+        let pto = convert_mlir_to_pto(mlir).expect("partition cell PTO-MLIR");
+        assert!(
+            pto.contains("offsets = [%c16, %c32]"),
+            "cell (1,1) of a 16x32 partition must sit at [row=16, col=32]:\n{}",
+            pto
+        );
+        assert!(
+            pto.contains("sizes = [%c16, %c32]"),
+            "cell extent must be the tile 16x32:\n{}",
+            pto
+        );
+    }
+
+    #[test]
+    fn test_pto_partition_cell_store_lowers_to_tstore_view() {
+        // The _mut form is a store DESTINATION: it must emit a pto.tstore into a
+        // partition_view (a tload here would silently drop the write), and the
+        // view must COVER the cell (rows/cols raised to the grid the index
+        // implies: max(16, (1+1)*16) x max(32, (1+1)*32) = 32x64).
+        let mlir = r#"
+module {
+  llvm.func @part_cell_store(%arg0: !llvm.ptr<1>, %arg1: !llvm.ptr<1>) attributes {hacc.entry} {
+    %t = llvm.call @__tile_load_f32(%arg0, %c16, %c32) : (!llvm.ptr<1>, i32, i32) -> i32
+    %dst = llvm.call @__tile_partition_cell_mut_f32(%t, %c1, %c1, %c16, %c32) : (i32, i32, i32, i32, i32) -> i32
+    llvm.return
+  }
+}
+"#;
+        let pto = convert_mlir_to_pto(mlir).expect("partition cell store PTO-MLIR");
+        assert!(
+            pto.contains("pto.tstore ins("),
+            "the _mut form must STORE (a tload silently drops the write):\n{}",
+            pto
+        );
+        assert!(
+            pto.contains("offsets = [%c16, %c32]"),
+            "cell (1,1) store base must be [row=16, col=32]:\n{}",
+            pto
+        );
+        assert!(
+            !pto.contains("pto.tload ins(%dst"),
+            "store destination must not also be loaded:\n{}",
+            pto
+        );
+    }
+
+    #[test]
+    fn test_pto_partition_cell_thm_partdisj_rejections() {
+        // thm:partdisj's hypotheses are ENFORCED, not assumed: a ragged split, a
+        // zero extent, or an out-of-grid cell has no established disjointness
+        // and must fail closed with a diagnostic naming the theorem.
+        let base = |ci: &str, cj: &str, tr: &str, tc: &str, rows: u32, cols: u32| {
+            format!(
+                "module {{\n  \
+                 llvm.func @k(%arg0: !llvm.ptr<1>) attributes {{hacc.entry}} {{\n    \
+                 %t = llvm.call @__tile_load_f32(%arg0, %c{rows}, %c{cols}) : (!llvm.ptr<1>, i32, i32) -> i32\n    \
+                 %cell = llvm.call @__tile_partition_cell_f32(%t, {ci}, {cj}, {tr}, {tc}) : (i32, i32, i32, i32, i32) -> i32\n    \
+                 llvm.return\n  }}\n}}\n"
+            )
+        };
+        // Ragged: 32x65 does not divide into 16x32 cells.
+        let err = convert_mlir_to_pto(&base("%c1", "%c1", "%c16", "%c32", 32, 65))
+            .expect_err("ragged partition must not lower");
+        assert!(err.contains("ragged") && err.contains("partdisj"), "{}", err);
+        // Zero extent: Tr=0 violates Tr>0.
+        let err = convert_mlir_to_pto(&base("%c1", "%c1", "%c0", "%c32", 32, 64))
+            .expect_err("zero-extent tile must not lower");
+        assert!(err.contains("positive"), "{}", err);
+        // Out-of-grid: cell (2,1) of a 2x2 grid (32x64 / 16x32) is outside.
+        let err = convert_mlir_to_pto(&base("%c2", "%c1", "%c16", "%c32", 32, 64))
+            .expect_err("out-of-grid cell must not lower");
+        assert!(err.contains("outside the 2x2 grid"), "{}", err);
+    }
+
+    #[test]
+    fn test_pto_validate_tile_shape_arch_bounds() {
+        // Plain row-major data tile: in bounds on every arch (16x8 f32, footprint 512B).
+        assert!(validate_tile_shape::<A2A3>(16, 8, "f32", "rows=16, cols=8").is_ok());
+        assert!(validate_tile_shape::<A5>(16, 8, "f32", "rows=16, cols=8").is_ok());
+        // C2: a row spanning multiple fractals must stride on 512B — 144 f32 cols
+        // = 576B is misaligned.
+        let err = validate_tile_shape::<A2A3>(16, 144, "f32", "rows=16, cols=144")
+            .expect_err("misaligned multi-fractal row must fail");
+        assert!(err.contains("(C2)"), "{}", err);
+        // C3: a5 (not a2a3) requires 16-aligned rows for NZ/cube tiles.
+        let err = validate_tile_shape::<A5>(17, 8, "f16", "rows=17, cols=8")
+            .expect_err("17-row f16 tile on a5 must fail row16");
+        assert!(err.contains("not 16-aligned (C3"), "{}", err);
+        assert!(validate_tile_shape::<A2A3>(17, 8, "f16", "rows=17, cols=8").is_ok());
+        // C3-reduce: col_major reduction tiles need rows*sizeof % 32 == 0 (4 f32
+        // rows = 16B fails; 8 rows = 32B passes).
+        let red = |rows: u32| format!("rows={rows}, cols=1, blayout=col_major, slayout=none_box");
+        let err = validate_tile_shape::<A2A3>(4, 1, "f32", &red(4))
+            .expect_err("4-row col_major f32 reduction must fail 32B align");
+        assert!(err.contains("C3-reduce"), "{}", err);
+        assert!(validate_tile_shape::<A2A3>(8, 1, "f32", &red(8)).is_ok());
+    }
+
+    #[test]
     fn test_pto_matmul_i8_unknown_errs() {
         // matmul_i8: (c0, a, b, scale_ptr, m, k, n) — unknown A tile.
         let call = "%r = llvm.call @__tile_matmul_i8_acc_i32_dequant_f16(%c0, %undef, %undef2, %arg1, %c16, %c16, %c16) : (i32, i32, i32, !llvm.ptr<1>, i32, i32, i32) -> i32";


### PR DESCRIPTION
## Problem

Since 2026-07-27 every push / PR on `main` has partially failed CI: the `coverage` workflow fails while `toolchain-drift` stays green. Two phases:

1. **07-27** — the `emitters: sync mlir_to_msl / mlir_to_pto with the partition work` batch broke the tile_spec `cucumber` test binary (`tile_spec produced no coverage`). Resolved upstream by the 08-04/05 batch.
2. **08-05 → now** — tests pass again, but the emitter batch added ~1,574 lines to `mlir_to_msl.rs` / `mlir_to_pto.rs` (q4_K fused matvecs, attn-decode variants, q4k / i8-v4 matvecs, batched rope / rms_norm / silu_mul / kv_write, partition cells, simdgroup matmul) **without the per-function tests the older members of each family carry**. Only ~343 of those lines are exercised, so tile_spec fell 90.05% → 87.34% and the gate fails:

```
GATE FAIL: total line coverage 87.44% < threshold 88%
```

## Fix

Add the missing tests, following each family's established in-source pattern (no CI/harness changes — the tile_spec cucumber harness already runs the emitters' `#[cfg(test)]` modules via `#[path]` includes):

- **msl** — 23 `t_emit_*` `check`-style tests (non-empty + deterministic + contains-idiom), one per new emitter. The `partition_cell{,_store}` tests assert **both** the `p1` and `p3` destinations, locking the "cell kernels write the LAST buffer" fix.
- **pto** — positive partition-cell lowerings (cell (1,1) base `[row=16, col=32]` via direct offsets; the `_mut` form must emit `pto.tstore`, never a `tload`), the **thm:partdisj fail-closed rejections** (ragged split / zero extent / out-of-grid cell), and direct `validate_tile_shape` checks for the C2 / C3 / C3-reduce arch bounds.

## Result

| | before | after |
|---|---|---|
| tile_spec | 87.34% | **89.85%** |
| TOTAL | 87.44% | **89.89%** |

`bash scripts/coverage.sh --gate 88` → **GATE OK** with ~1.9 points of headroom, restoring the ratchet margin the gate was designed around (set ~2 points below achieved). All 790 tile_spec tests and 795 tile_codegen (`--features emitters`) tests pass.